### PR TITLE
Remove RG field Mask

### DIFF
--- a/assets/js/frontend/checkout.masks.js
+++ b/assets/js/frontend/checkout.masks.js
@@ -11,17 +11,6 @@
 			// CPF.
 			$( '#billing_cpf, #credit-card-cpf' ).mask( '999.999.999-99' );
 
-			// RG.
-			$( '#billing_rg' ).keyup( function () {
-				var current = $( this ),
-					notNumber = new RegExp( '[^0-9]', 'g' ),
-					currentValue = current.val();
-
-				if ( currentValue.match( notNumber ) ) {
-					current.val( currentValue.replace( notNumber, '' ) );
-				}
-			}).keyup();
-
 			// CPNJ.
 			$( '#billing_cnpj' ).mask( '99.999.999/9999-99' );
 


### PR DESCRIPTION
You can not specify a mask for RG field because there is no standard for RG , including some old RGs used alphanumeric characters.
