### PR TITLE
Facilitar Integração do Plugin

### DIFF
--- a/includes/class-wc-ecfb-front-end.php
+++ b/includes/class-wc-ecfb-front-end.php
@@ -70,9 +70,7 @@ class Extra_Checkout_Fields_For_Brazil_Front_End {
 	 * Register scripts.
 	 */
 	public function enqueue_scripts() {
-		if ( ! is_checkout() ) {
-			return;
-		}
+		
 
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
@@ -103,6 +101,10 @@ class Extra_Checkout_Fields_For_Brazil_Front_End {
 	 * Load scripts.
 	 */
 	public function load_scripts() {
+		if ( ! is_checkout() ) {
+			return;
+		}
+		
 		wp_enqueue_script( 'woocommerce-extra-checkout-fields-for-brazil-front' );
 	}
 

--- a/includes/class-wc-ecfb-front-end.php
+++ b/includes/class-wc-ecfb-front-end.php
@@ -70,8 +70,6 @@ class Extra_Checkout_Fields_For_Brazil_Front_End {
 	 * Register scripts.
 	 */
 	public function enqueue_scripts() {
-		
-
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
 		wp_register_script( 'jquery-maskedinput', plugins_url( 'assets/js/jquery-maskedinput/jquery.maskedinput' . $suffix . '.js', plugin_dir_path( __FILE__ ) ), array( 'jquery' ), '1.4.1', true );
@@ -101,10 +99,6 @@ class Extra_Checkout_Fields_For_Brazil_Front_End {
 	 * Load scripts.
 	 */
 	public function load_scripts() {
-		if ( ! is_checkout() ) {
-			return;
-		}
-		
 		wp_enqueue_script( 'woocommerce-extra-checkout-fields-for-brazil-front' );
 	}
 


### PR DESCRIPTION
Plugin alterado para permitir reuso dos arquivos de javascript do mesmo, permitindo que outros plugins façam uso do js fora da página do checkout.

Uso case: No plugin WooCommerce NFe, https://github.com/nfe/woo-nfe, temos um endpoint na Minha Conta onde o usuário pode atualizar as informações de emissão de nota fiscal.

A alteração sugerida nesse commit, me permite carregar os arquivos js do plugin fora do checkout, no endpoint criado, e tomar proveito das funcionalidades do plugin definidas pelo admin nas configurações do mesmo.