### PR TITLE
Correção de warning por uso de index não definido

### DIFF
--- a/includes/class-extra-checkout-fields-for-brazil-front-end.php
+++ b/includes/class-extra-checkout-fields-for-brazil-front-end.php
@@ -475,6 +475,11 @@ class Extra_Checkout_Fields_For_Brazil_Front_End {
 	 * @return array               New replacements.
 	 */
 	public function formatted_address_replacements( $replacements, $args ) {
+		$args = wp_parse_args( $args, array(
+			'number'       => '',
+			'neighborhood' => '',
+		) );
+
 		$replacements['{number}']       = $args['number'];
 		$replacements['{neighborhood}'] = $args['neighborhood'];
 


### PR DESCRIPTION
A função `formatted_address_replacements` com `WP_DEBUG` ativado causa um warning por utilizar indexes inválidos. Defini os valores padrões (em branco) para os indexes utilizados.