### PR TITLE
Altera as configurações do plugin e as opções de exibição dos campos CPF, CNPJ e IE para permitir a validação de campos nativa do WooCommerce ou de terceiros.

### DIFF
--- a/includes/admin/class-extra-checkout-fields-for-brazil-settings.php
+++ b/includes/admin/class-extra-checkout-fields-for-brazil-settings.php
@@ -180,6 +180,48 @@ class Extra_Checkout_Fields_For_Brazil_Settings {
 			)
 		);
 
+		// CPF is required option.
+		add_settings_field(
+			'cpf_required',
+			__( 'Display CPF as required:', 'woocommerce-extra-checkout-fields-for-brazil' ),
+			array( $this, 'checkbox_element_callback' ),
+			$option,
+			'options_section',
+			array(
+				'menu'  => $option,
+				'id'    => 'cpf_required',
+				'label' => __( 'If checked, the CPF field will be a required field.', 'woocommerce-extra-checkout-fields-for-brazil' ),
+			)
+		);
+		
+		// CNPJ is required option.
+		add_settings_field(
+			'cnpj_required',
+			__( 'Display CNPJ as required:', 'woocommerce-extra-checkout-fields-for-brazil' ),
+			array( $this, 'checkbox_element_callback' ),
+			$option,
+			'options_section',
+			array(
+				'menu'  => $option,
+				'id'    => 'cnpj_required',
+				'label' => __( 'If checked, the CNPJ field will be a required field.', 'woocommerce-extra-checkout-fields-for-brazil' ),
+			)
+		);
+		
+		// IE is required option.
+		add_settings_field(
+			'ie_required',
+			__( 'Display IE as required:', 'woocommerce-extra-checkout-fields-for-brazil' ),
+			array( $this, 'checkbox_element_callback' ),
+			$option,
+			'options_section',
+			array(
+				'menu'  => $option,
+				'id'    => 'ie_required',
+				'label' => __( 'If checked, the State Registration field will be a required field.', 'woocommerce-extra-checkout-fields-for-brazil' ),
+			)
+		);
+
 		// Set Design section.
 		add_settings_section(
 			'design_section',

--- a/includes/class-extra-checkout-fields-for-brazil-front-end.php
+++ b/includes/class-extra-checkout-fields-for-brazil-front-end.php
@@ -130,7 +130,7 @@ class Extra_Checkout_Fields_For_Brazil_Front_End {
 					'label'       => __( 'Person type', 'woocommerce-extra-checkout-fields-for-brazil' ),
 					'class'       => array( 'form-row-wide', 'person-type-field' ),
 					'input_class' => array( 'wc-ecfb-select' ),
-					'required'    => false,
+					'required'    => true, /* If the person type field is being displayed on the frontend, it should be required anyway */
 					'options'     => array(
 						'1' => __( 'Individuals', 'woocommerce-extra-checkout-fields-for-brazil' ),
 						'2' => __( 'Legal Person', 'woocommerce-extra-checkout-fields-for-brazil' ),
@@ -144,7 +144,7 @@ class Extra_Checkout_Fields_For_Brazil_Front_End {
 					$new_fields['billing_cpf'] = array(
 						'label'    => __( 'CPF', 'woocommerce-extra-checkout-fields-for-brazil' ),
 						'class'    => array( $first_class, 'person-type-field' ),
-						'required' => false,
+						'required' => boolval($settings['cpf_required'] ?? 0),
 						'type'     => 'tel',
 						'priority' => 23,
 					);
@@ -159,7 +159,7 @@ class Extra_Checkout_Fields_For_Brazil_Front_End {
 					$new_fields['billing_cpf'] = array(
 						'label'    => __( 'CPF', 'woocommerce-extra-checkout-fields-for-brazil' ),
 						'class'    => array( 'form-row-wide', 'person-type-field' ),
-						'required' => false,
+						'required' => boolval($settings['cpf_required'] ?? 0),
 						'type'     => 'tel',
 						'priority' => 23,
 					);
@@ -178,7 +178,7 @@ class Extra_Checkout_Fields_For_Brazil_Front_End {
 					$new_fields['billing_cnpj'] = array(
 						'label'    => __( 'CNPJ', 'woocommerce-extra-checkout-fields-for-brazil' ),
 						'class'    => array( $first_class, 'person-type-field' ),
-						'required' => false,
+						'required' => boolval($settings['cnpj_required'] ?? 0),
 						'type'     => 'tel',
 						'priority' => 26,
 					);
@@ -186,14 +186,14 @@ class Extra_Checkout_Fields_For_Brazil_Front_End {
 					$new_fields['billing_ie'] = array(
 						'label'    => __( 'State Registration', 'woocommerce-extra-checkout-fields-for-brazil' ),
 						'class'    => array( $last_class, 'person-type-field' ),
-						'required' => false,
+						'required' => boolval($settings['ie_required'] ?? 0),
 						'priority' => 27,
 					);
 				} else {
 					$new_fields['billing_cnpj'] = array(
 						'label'    => __( 'CNPJ', 'woocommerce-extra-checkout-fields-for-brazil' ),
 						'class'    => array( 'form-row-wide', 'person-type-field' ),
-						'required' => false,
+						'required' => boolval($settings['cnpj_required'] ?? 0),
 						'type'     => 'tel',
 						'priority' => 26,
 					);

--- a/includes/class-extra-checkout-fields-for-brazil-front-end.php
+++ b/includes/class-extra-checkout-fields-for-brazil-front-end.php
@@ -130,7 +130,7 @@ class Extra_Checkout_Fields_For_Brazil_Front_End {
 					'label'       => __( 'Person type', 'woocommerce-extra-checkout-fields-for-brazil' ),
 					'class'       => array( 'form-row-wide', 'person-type-field' ),
 					'input_class' => array( 'wc-ecfb-select' ),
-					'required'    => false
+					'required'    => false,
 					'options'     => array(
 						'1' => __( 'Individuals', 'woocommerce-extra-checkout-fields-for-brazil' ),
 						'2' => __( 'Legal Person', 'woocommerce-extra-checkout-fields-for-brazil' ),

--- a/includes/class-extra-checkout-fields-for-brazil-front-end.php
+++ b/includes/class-extra-checkout-fields-for-brazil-front-end.php
@@ -130,7 +130,7 @@ class Extra_Checkout_Fields_For_Brazil_Front_End {
 					'label'       => __( 'Person type', 'woocommerce-extra-checkout-fields-for-brazil' ),
 					'class'       => array( 'form-row-wide', 'person-type-field' ),
 					'input_class' => array( 'wc-ecfb-select' ),
-					'required'    => true, /* If the person type field is being displayed on the frontend, it should be required anyway */
+					'required'    => false
 					'options'     => array(
 						'1' => __( 'Individuals', 'woocommerce-extra-checkout-fields-for-brazil' ),
 						'2' => __( 'Legal Person', 'woocommerce-extra-checkout-fields-for-brazil' ),
@@ -144,11 +144,19 @@ class Extra_Checkout_Fields_For_Brazil_Front_End {
 					$new_fields['billing_cpf'] = array(
 						'label'    => __( 'CPF', 'woocommerce-extra-checkout-fields-for-brazil' ),
 						'class'    => array( $first_class, 'person-type-field' ),
-						'required' => boolval($settings['cpf_required'] ?? 0),
+						'required' => false,
 						'type'     => 'tel',
 						'priority' => 23,
 					);
-
+					if ( isset( $settings['cpf_required'] ) && '1' === $settings['cpf_required'] ) {
+						add_filter('woocommerce_form_field_args', function( $args, $key, $value ) {
+	  						if ( 'billing_cpf' === $key ) {
+								$args['required'] = true;
+							}
+							return $args;
+						}, 9999, 3);
+					}
+					
 					$new_fields['billing_rg'] = array(
 						'label'    => __( 'RG', 'woocommerce-extra-checkout-fields-for-brazil' ),
 						'class'    => array( $last_class, 'person-type-field' ),
@@ -159,10 +167,18 @@ class Extra_Checkout_Fields_For_Brazil_Front_End {
 					$new_fields['billing_cpf'] = array(
 						'label'    => __( 'CPF', 'woocommerce-extra-checkout-fields-for-brazil' ),
 						'class'    => array( 'form-row-wide', 'person-type-field' ),
-						'required' => boolval($settings['cpf_required'] ?? 0),
+						'required' => false,
 						'type'     => 'tel',
 						'priority' => 23,
 					);
+					if ( isset( $settings['cpf_required'] ) && '1' === $settings['cpf_required'] ) {
+						add_filter('woocommerce_form_field_args', function( $args, $key, $value ) {
+	  						if ( 'billing_cpf' === $key ) {
+								$args['required'] = true;
+							}
+							return $args;
+						}, 9999, 3);
+					}
 				}
 			}
 
@@ -178,25 +194,49 @@ class Extra_Checkout_Fields_For_Brazil_Front_End {
 					$new_fields['billing_cnpj'] = array(
 						'label'    => __( 'CNPJ', 'woocommerce-extra-checkout-fields-for-brazil' ),
 						'class'    => array( $first_class, 'person-type-field' ),
-						'required' => boolval($settings['cnpj_required'] ?? 0),
+						'required' => false,
 						'type'     => 'tel',
 						'priority' => 26,
 					);
+					if ( isset( $settings['cnpj_required'] ) && '1' === $settings['cnpj_required'] ) {
+						add_filter('woocommerce_form_field_args', function( $args, $key, $value ) {
+	  						if ( 'billing_cnpj' === $key ) {
+								$args['required'] = true;
+							}
+							return $args;
+						}, 9999, 3);
+					}
 
 					$new_fields['billing_ie'] = array(
 						'label'    => __( 'State Registration', 'woocommerce-extra-checkout-fields-for-brazil' ),
 						'class'    => array( $last_class, 'person-type-field' ),
-						'required' => boolval($settings['ie_required'] ?? 0),
+						'required' => false,
 						'priority' => 27,
 					);
+					if ( isset( $settings['ie_required'] ) && '1' === $settings['ie_required'] ) {
+						add_filter('woocommerce_form_field_args', function( $args, $key, $value ) {
+	  						if ( 'billing_ie' === $key ) {
+								$args['required'] = true;
+							}
+							return $args;
+						}, 9999, 3);
+					}
 				} else {
 					$new_fields['billing_cnpj'] = array(
 						'label'    => __( 'CNPJ', 'woocommerce-extra-checkout-fields-for-brazil' ),
 						'class'    => array( 'form-row-wide', 'person-type-field' ),
-						'required' => boolval($settings['cnpj_required'] ?? 0),
+						'required' => false,
 						'type'     => 'tel',
 						'priority' => 26,
 					);
+					if ( isset( $settings['cnpj_required'] ) && '1' === $settings['cnpj_required'] ) {
+						add_filter('woocommerce_form_field_args', function( $args, $key, $value ) {
+	  						if ( 'billing_cnpj' === $key ) {
+								$args['required'] = true;
+							}
+							return $args;
+						}, 9999, 3);
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
Estou desenvolvendo uma solução própria para a página de checkout e me deparei com o problema que, caso não utilize a estrutura de HTML padão do WooCommerce, os campo "Tipo de Pessoa", "CPF", "CNPJ" e "IE" são apresentados como opcionais. O plugin no momento impede a definição dos campos como 'required', realizando a conversão e o tratamento diretamente via jQuery. Porém, isso impossibilita que esses campos sejam de fato tratados como obrigatórios pelo WooCommerce ou por código de terceiros.

A alteração proposta permite que o usuário defina os campos mencionados como obrigatórios.

**ANTES**
![antes1](https://github.com/user-attachments/assets/55b9ab69-3032-4eb4-b6fb-192591fbe654)
![antes2](https://github.com/user-attachments/assets/404f39d7-9e57-4db3-a5f1-f5fbfb827657)

**DEPOIS**
![depois_1](https://github.com/user-attachments/assets/bc25acd9-3727-4b96-9dfc-908529c0968a)
![depois_2](https://github.com/user-attachments/assets/5e1ba6e0-7d61-41da-9986-bd057fabce11)
